### PR TITLE
Check for hold down keys feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>lc.kra.system</groupId>
 	<artifactId>system-hook</artifactId>
-<<<<<<< HEAD
-	<version>3.4</version>
-=======
-	<version>3.5</version>
->>>>>>> master
+	<version>3.6</version>
 	<description>Global Keyboard / Mouse Hook for Java applications.</description>
 	<url>https://github.com/kristian/system-hook</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>lc.kra.system</groupId>
 	<artifactId>system-hook</artifactId>
-	<version>3.3</version>
+	<version>3.4</version>
 	<description>Global Keyboard / Mouse Hook for Java applications.</description>
 	<url>https://github.com/kristian/system-hook</url>
 

--- a/src/main/java/lc/kra/system/keyboard/GlobalKeyboardHook.java
+++ b/src/main/java/lc/kra/system/keyboard/GlobalKeyboardHook.java
@@ -60,8 +60,7 @@ public class GlobalKeyboardHook {
 	
 	private List<GlobalKeyListener> listeners = new CopyOnWriteArrayList<GlobalKeyListener>();
 	
-	private Set<Integer> holdDownKeyCodes = new HashSet<Integer>();
-	
+	private Set<Integer> heldDownKeyCodes = new HashSet<Integer>();
 	
 	private Thread eventDispatcher = new Thread() {{
 			setName("Global Keyboard Hook Dispatcher");
@@ -152,12 +151,7 @@ public class GlobalKeyboardHook {
 	 * @param event A global key event
 	 */
 	private void keyPressed(GlobalKeyEvent event) {
-		
-		int virtualKeyCode = event.getVirtualKeyCode();
-		
-		// only add if key is not already hold down
-		if(!isKeyHoldDown(event))
-			holdDownKeyCodes.add(virtualKeyCode);
+		heldDownKeyCodes.add(event.getVirtualKeyCode());
 		
 		for(GlobalKeyListener listener:listeners)
 			listener.keyPressed(event);
@@ -169,47 +163,38 @@ public class GlobalKeyboardHook {
 	 * @param event A global key event
 	 */
 	private void keyReleased(GlobalKeyEvent event) {
-
-		int virtualKeyCode = event.getVirtualKeyCode();
-
-		// redundant if - key should always be hold down if you can release it, but you never know
-		if(isKeyHoldDown(event))
-			holdDownKeyCodes.remove(virtualKeyCode);
+		heldDownKeyCodes.remove(event.getVirtualKeyCode());
 		
 		for(GlobalKeyListener listener:listeners)
 			listener.keyReleased(event);
 	}
 
 	/**
-	 * Checks if the specified key is currently hold down
+	 * Checks if the specified key is currently held down
 	 * 
 	 * @param virtualKeyCode the virtual code of the key, use constants in {@link GlobalKeyEvent}
 	 * 
-	 * @return true if the key is currently hold down
+	 * @return true if the key is currently held down
 	 */
-	public boolean isKeyHoldDown(int virtualKeyCode) {
-		return holdDownKeyCodes.contains(virtualKeyCode);
+	public boolean isKeyHeldDown(int virtualKeyCode) {
+		return heldDownKeyCodes.contains(virtualKeyCode);
 	}
 	
 	
 	/**
-	 * Checks if all the specified keys are currently hold down
+	 * Checks if all the specified keys are currently held down
 	 * 
 	 * @param virtualKeyCodes any number of specified key codes, use constants in {@link GlobalKeyEvent}
 	 * 
-	 * @return true if all the specified keys are currently hold down, false if any of the keys is not currently hold down
+	 * @return true if all the specified keys are currently held down, false if any of the keys is not currently held down
 	 */
-	public boolean areKeysHoldDown(int... virtualKeyCodes) {
+	public boolean areKeysHeldDown(int... virtualKeyCodes) {
 		for(int keyCode : virtualKeyCodes) {
-			if(!isKeyHoldDown(keyCode)) {
+			if(!isKeyHeldDown(keyCode)) {
 				return false;
 			}
 		}
 		return true;
-	}
-	
-	private boolean isKeyHoldDown(GlobalKeyEvent event) {
-		return isKeyHoldDown(event.getVirtualKeyCode());
 	}
 	
 	/**


### PR DESCRIPTION
I added a Set in GlobalKeyboardHook to track the currently hold down keys. There is a method to check if a key is currenlty hold down by providing the virtualKeyCode (constants from GlobalKeyEvent can be used). Another method takes multiple keyCodes to check if all of them are currently hold down.

This should fix #43 in my understanding, but even if not i guess it is still a nice feature.

While writing this I recognize this would trigger for every keyListener global if there are more than one. So maybe we should add the check methods and the Set into GlobalKeyListener interface and also add a method addHoldDownKey to call in the for loop of GlobalKeyboardHook#keyPressed and GlobalKeyboardHook#keyReleased. But this must be public and could also be called in the adapter class to add random key to the set...

Can you confirm @kristian ?

EDIT: Or maybe it is fine, that hold down keys are stored global for all key listener, since key events in 
GlobalKeyboardHook#keyPressed and GlobalKeyboardHook#keyReleased are also for each key listener. Help me out, I am confused.

Example:
```
import java.util.Map.Entry;

import lc.kra.system.keyboard.GlobalKeyboardHook;
import lc.kra.system.keyboard.event.GlobalKeyAdapter;
import lc.kra.system.keyboard.event.GlobalKeyEvent;

public class KeyReleaseTest {

	public static void main(String[] args) {
		GlobalKeyboardHook keyboardHook = new GlobalKeyboardHook(true); // Use false here to switch to hook instead of raw input
		for (Entry<Long, String> keyboard : GlobalKeyboardHook.listKeyboards().entrySet()) {
			System.out.format("%d: %s\n", keyboard.getKey(), keyboard.getValue());
		}
		keyboardHook.addKeyListener(new GlobalKeyAdapter() {
			
			@Override 
			public void keyPressed(GlobalKeyEvent event) {
				if(isAltCtrlADown()) {
					System.out.println("Alt + Ctrl + A is currently hold down.");
				}
			}
			
			@Override
			public void keyReleased(GlobalKeyEvent event) {
				if(!isAltCtrlADown()) {
					System.out.println("Alt + Ctrl + A is no more hold down.");
				}
			}
			
			private boolean isAltCtrlADown(){
				return keyboardHook.areKeysHoldDown(GlobalKeyEvent.VK_MENU, GlobalKeyEvent.VK_CONTROL, GlobalKeyEvent.VK_A);
			}
		});

		while (true) {
			try {
				Thread.sleep(128);
			} catch (InterruptedException e) {
				// do nothing
			}
		}

	}

}
```
